### PR TITLE
follow current state

### DIFF
--- a/ansible/monitoring.yml
+++ b/ansible/monitoring.yml
@@ -1,6 +1,6 @@
 ---
 - name: Install Monitoring things
-  hosts: all
+  hosts: mastodon
   become: true
   gather_facts: true
   roles:

--- a/ansible/roles/mastodon_update_compose/templates/docker-compose.j2
+++ b/ansible/roles/mastodon_update_compose/templates/docker-compose.j2
@@ -76,8 +76,8 @@ services:
     image: tootsuite/mastodon:{{mastodon_git.json.tag_name}}
     restart: always
     env_file: .env.production
-    command: bundle exec sidekiq -c 15
-    mem_limit: 512M
+    command: bundle exec sidekiq -c 10 -q scheduler -q mailers -q default -q push -q ingress -q pull
+    mem_limit: 768M
     logging:
       driver: awslogs
       options:

--- a/ansible/roles/monitoring/tasks/main.yml
+++ b/ansible/roles/monitoring/tasks/main.yml
@@ -1,6 +1,5 @@
 ---
-- name: Install loki docker logdriver plugin
-  community.docker.docker_plugin:
-    plugin_name: grafana/loki-docker-driver
-    state: enable
-    alias: loki
+- name: Remove datadog-agent package with apt
+  ansible.builtin.package:
+    name: datadog-agent
+    state: absent


### PR DESCRIPTION
* datadog-agent is not used anymore.
* alternatively, cloudwatch logs is selected.
* vega struggle high swap usage, and it make service unstalbe. use more memory, prioritize queues.